### PR TITLE
Require modern TLS and pin scanner dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
 
 ### Prerequisites
 
-- Python 3.6 or higher
+- Python 3.10 or higher
 - `pip` package manager
 
 ### Clone the Repository
@@ -59,15 +59,6 @@ python3 -m venv venv
 source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
 
 pip install -r requirements.txt
-```
-
-**Ensure `requirements.txt` includes all necessary packages:**
-
-```
-requests
-termcolor
-concurrent.futures
-[other dependencies]
 ```
 
 ---

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+beautifulsoup4==4.15.0
+cryptography==49.0.0
+idna==3.18
+requests==2.34.2
+selenium==4.45.0
+termcolor==3.3.0

--- a/tests/ssl_tls.py
+++ b/tests/ssl_tls.py
@@ -7,11 +7,19 @@ from cryptography.hazmat.backends import default_backend
 from datetime import datetime, timezone
 from tests.firewall_detection import check_for_firewall
 
+
+def create_secure_ssl_context():
+    """Create a certificate-verifying client context that rejects legacy TLS."""
+    context = ssl.create_default_context()
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    return context
+
+
 def check_ssl_certificate(domain):
     result = {'status': True, 'details': '', 'remediation': ''}
     
     try:
-        ctx = ssl.create_default_context()
+        ctx = create_secure_ssl_context()
         with ctx.wrap_socket(socket.socket(), server_hostname=domain) as s:
             s.settimeout(5)
             s.connect((domain, 443))

--- a/tests/test_domain_validation.py
+++ b/tests/test_domain_validation.py
@@ -1,32 +1,13 @@
 import unittest
-import importlib
-import builtins
-from types import ModuleType
+
+import vulncheck
 
 class DomainValidationTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.orig_import = builtins.__import__
-
-        def dummy_import(name, globals=None, locals=None, fromlist=(), level=0):
-            try:
-                return cls.orig_import(name, globals, locals, fromlist, level)
-            except ModuleNotFoundError:
-                mod = ModuleType(name)
-                if fromlist:
-                    for attr in fromlist:
-                        setattr(mod, attr, ModuleType(f"{name}.{attr}"))
-                return mod
-
-        builtins.__import__ = dummy_import
-        cls.vulncheck = importlib.import_module("vulncheck")
-        builtins.__import__ = cls.orig_import
-
     def test_valid_domain(self):
-        self.assertTrue(bool(self.vulncheck.is_valid_domain("example.com")))
+        self.assertTrue(bool(vulncheck.is_valid_domain("example.com")))
 
     def test_invalid_domain(self):
-        self.assertFalse(bool(self.vulncheck.is_valid_domain("bad_domain")))
+        self.assertFalse(bool(vulncheck.is_valid_domain("bad_domain")))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ssl_context.py
+++ b/tests/test_ssl_context.py
@@ -1,0 +1,17 @@
+import ssl
+import unittest
+
+from tests.ssl_tls import create_secure_ssl_context
+
+
+class SecureSslContextTests(unittest.TestCase):
+    def test_rejects_legacy_tls_versions(self):
+        context = create_secure_ssl_context()
+
+        self.assertEqual(context.minimum_version, ssl.TLSVersion.TLSv1_2)
+        self.assertEqual(context.verify_mode, ssl.CERT_REQUIRED)
+        self.assertTrue(context.check_hostname)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Security remediation

- Requires TLS 1.2 or newer while preserving certificate and hostname verification.
- Adds a regression test for the SSL context.
- Adds complete, pinned runtime dependencies and fixes the existing import-mocking test now that dependencies are declared.
- Pins IDNA above the patched security floor.

## Validation

- Clean virtual-environment install and `pip check`: passed
- Unit tests: 3/3 passed
- Python compile check: passed
- OSV-Scanner and Trivy: 0 vulnerabilities
- Gitleaks: 0 repository leaks
- Extended CodeQL will verify closure of `py/insecure-protocol`